### PR TITLE
Extra middle_z and idForTracking fields in message definition.

### DIFF
--- a/msg/PointCloud2_Segments.msg
+++ b/msg/PointCloud2_Segments.msg
@@ -13,3 +13,5 @@
   float32 range_max
   float32 scan_time
   time rec_time 
+  float64 middle_z
+  int32 idForTracking


### PR DESCRIPTION
Μiddle_z variable contains the middle z value of the sixty laser scans.

The variable idForTracking will contain the id of the cluster that was first moved. This cluster will be displayed at the output of "image_segmentation_node/seg_image" topic.    